### PR TITLE
ci: Add automated testing workflow via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install system dependencies (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libegl1-mesa libegl1
+
       - name: Install uv and setup python
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,9 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --extra cpu --frozen
+        run: |
+          uv sync --extra cpu --frozen
+          uv pip install pytest
 
       - name: Run PyTest
         run: uv run pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install system dependencies (Ubuntu only)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y libegl1-mesa libegl1
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1
 
       - name: Install uv and setup python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - mwcore-dev
+      - main
+  pull_request:
+    branches:
+      - mwcore-dev
+      - main
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv and setup python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --frozen
+
+      - name: Run PyTest
+        run: uv run pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: uv sync --extra cpu --frozen
 
       - name: Run PyTest
         run: uv run pytest tests/ -v

--- a/tests/test_raw_bin_integration.py
+++ b/tests/test_raw_bin_integration.py
@@ -11,23 +11,25 @@ from mwcore.registry import READERS
 from mwcore.radario.readers.offlineReaders.raw_bin_reader import RawBinReader
 
 class TestRawBinIntegration(unittest.TestCase):
+    FILE_PATH = os.path.join(os.path.dirname(__file__), 'data', 'sample.bin')
+
+    @unittest.skipIf(not os.path.exists(FILE_PATH), "sample.bin not found. Skipping raw data test.")
     def test_registry_instantiation(self):
         """Test that we can build the reader from the registry."""
-        file_path = os.path.join(os.path.dirname(__file__), 'data', 'sample.bin')
         
         cfg = dict(
             type='RawBinReader',
-            file_path=file_path
+            file_path=self.FILE_PATH
         )
         
         reader = READERS.build(cfg)
         self.assertIsInstance(reader, RawBinReader)
         return reader
 
+    @unittest.skipIf(not os.path.exists(FILE_PATH), "sample.bin not found. Skipping raw data test.")
     def test_read_frame(self):
         """Test reading and processing a frame."""
-        file_path = os.path.join(os.path.dirname(__file__), 'data', 'sample.bin')
-        reader = RawBinReader(file_path=file_path)
+        reader = RawBinReader(file_path=self.FILE_PATH)
         
         # Read first frame
         points = reader.read()


### PR DESCRIPTION
## Description
We need to enforce Continuous Integration to prevent broken code from being merged into mwcore-dev.

## Proposed Changes
1. Create a GitHub Actions workflow (`.github/workflows/ci.yml`).
2. The workflow will use `astral-sh/setup-uv` to bootstrap the environment rapidly.
3. Automatically run `pytest` on every pull request to ensure components like the 3D Tracking mathematical core work across different OS environments (Ubuntu and Mac).

Resolves #10